### PR TITLE
Restore circleci config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,49 +1,18 @@
-# pip-run: &pip-install
-#   name: Install Python dependencies
-#   command: |
-#     python3 -m venv venv
-#     . venv/bin/activate
-#     pip install pytest
-#     pip install -e .[cloudflare]
-
-
-# version: 2
-# jobs:
-#   nineanime:
-#     docker:
-#       - image: circleci/python:3.6
-#     steps:
-#       - checkout
-#       - run: *pip-install
-#       - run: venv/bin/python -m pytest tests/test_anime.py --anime-site nineanime
-#   kissanime:
-#     docker:
-#       - image: circleci/python:3.6
-#     steps:
-#       - checkout
-#       - run: *pip-install
-#       - run: venv/bin/python -m pytest tests/test_anime.py --anime-site kissanime
-#   gogoanime:
-#     docker:
-#       - image: circleci/python:3.6
-#     steps:
-#       - checkout
-#       - run: *pip-install
-#       - run: venv/bin/python -m pytest tests/test_anime.py --anime-site gogoanime
-
-# workflows:
-#   version: 2
-#   commit:
-#     jobs:
-#       - nineanime
-#       - gogoanime
-      # Kissanime will always fail on remote servers due to cloudflare
-      # - kissanime
-
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - master
+jobs:
+  build:
+    executor: python/default
+    steps:
+      - checkout
+      - python/install-packages:
+          args: pytest
+          pkg-manager: pipenv
+      - run: |
+          pipenv install --dev
+          pipenv run pytest
+orbs:
+  python: circleci/python@1.2.0
+version: 2.1
+workflows:
+  main:
+    jobs:
+      - build


### PR DESCRIPTION
This is just a quick build and test with circleci, so that the commits are green again. Not sure what the plan is though, if we want to have circleci do the exact same builds as travis, or if circleci should be removed altogether.