### PR TITLE
Animefreak: Set Episode Number manually when possible

### DIFF
--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -45,7 +45,7 @@ class AnimeFreakEpisode(AnimeEpisode, sitename='animefreak'):
         # E.g. episode-946
         url_end = self.url.split("/")[-1]
 
-        # To ensure that isn't a special/preview or something
+        # To ensure that it isn't a special/preview or something
         logger.info(url_end)
         if "episode" in url_end:
             episode_number_regexed = re.search("\d+", url_end)

--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -31,10 +31,10 @@ class AnimeFreak(Anime, sitename='animefreak'):
         episode_links = soup.select('ul.check-list')[-1].select('li a')
         episodes = [a.get('href') for a in episode_links][::-1]
 
-        # Get links ending with episode-74
+        # Get links ending with episode-.*, e.g. episode-74
         episode_numbers = [re.search("episode-(\d+)", x.split("/")[-1]).group(1) for x in episodes if re.search("episode-\d+", x.split("/")[-1])]
 
-        # Ensure that the number of episode numbers which have been extracted, match the number of episode
+        # Ensure that the number of episode numbers which have been extracted match the number of episodes
         if len(episodes) == len(episode_numbers):
             return [(x, y) for x, y in zip(episode_numbers, episodes)]
 

--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -49,7 +49,7 @@ class AnimeFreakEpisode(AnimeEpisode, sitename='animefreak'):
         logger.info(url_end)
         if "episode" in url_end:
             episode_number_regexed = re.search("\d+", url_end)
-            # Just in case we don't have the ep number in the url_end for some unexpected reason
+            # Just in case we don't have the ep number in url_end for some unexpected reason
             if episode_number_regexed:
                 self.ep_no = episode_number_regexed.group()
                 logger.info(self.ep_no)

--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -31,10 +31,10 @@ class AnimeFreak(Anime, sitename='animefreak'):
         episode_links = soup.select('ul.check-list')[-1].select('li a')
         episodes = [a.get('href') for a in episode_links][::-1]
 
-        # Get links ending eith episode-74
+        # Get links ending with episode-74
         episode_numbers = [re.search("episode-(\d+)", x.split("/")[-1]).group(1) for x in episodes if re.search("episode-\d+", x.split("/")[-1])]
 
-        # Ensure that the number of episode numbers which have been extracted, much the number of episode
+        # Ensure that the number of episode numbers which have been extracted, match the number of episode
         if len(episodes) == len(episode_numbers):
             return [(x, y) for x, y in zip(episode_numbers, episodes)]
 

--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -52,7 +52,6 @@ class AnimeFreakEpisode(AnimeEpisode, sitename='animefreak'):
             # Just in case we don't have the ep number in url_end for some unexpected reason
             if episode_number_regexed:
                 self.ep_no = episode_number_regexed.group()
-                logger.info(self.ep_no)
 
         if not match:
             raise NotFoundError(f'Failed to find video url for {self.url}')

--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -1,8 +1,11 @@
 import re
+import logging
 
 from anime_downloader.sites.anime import Anime, AnimeEpisode, SearchResult
 from anime_downloader.sites.exceptions import NotFoundError
 from anime_downloader.sites import helpers
+
+logger = logging.getLogger(__name__)
 
 
 class AnimeFreak(Anime, sitename='animefreak'):
@@ -41,6 +44,18 @@ class AnimeFreakEpisode(AnimeEpisode, sitename='animefreak'):
         page = helpers.get(self.url).text
         source_re = re.compile(r'loadVideo.+file: "([^"]+)', re.DOTALL)
         match = source_re.findall(page)
+
+        # E.g. episode-946
+        url_end = self.url.split("/")[-1]
+
+        # To ensure that isn't a special/preview or something
+        logger.info(url_end)
+        if "episode" in url_end:
+            episode_number_regexed = re.search("\d+", url_end)
+            # Just in case we don't have the ep number in the url_end for some unexpected reason
+            if episode_number_regexed:
+                self.ep_no = episode_number_regexed.group()
+                logger.info(self.ep_no)
 
         if not match:
             raise NotFoundError(f'Failed to find video url for {self.url}')

--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -32,7 +32,7 @@ class AnimeFreak(Anime, sitename='animefreak'):
         episodes = [a.get('href') for a in episode_links][::-1]
 
         # Get links ending with episode-.*, e.g. episode-74
-        episode_numbers = [re.search("episode-(\d+)", x.split("/")[-1]).group(1) for x in episodes if re.search("episode-\d+", x.split("/")[-1])]
+        episode_numbers = [int(re.search("episode-(\d+)", x.split("/")[-1]).group(1)) for x in episodes if re.search("episode-\d+", x.split("/")[-1])]
 
         # Ensure that the number of episode numbers which have been extracted match the number of episodes
         if len(episodes) == len(episode_numbers):

--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -1,11 +1,8 @@
 import re
-import logging
 
 from anime_downloader.sites.anime import Anime, AnimeEpisode, SearchResult
 from anime_downloader.sites.exceptions import NotFoundError
 from anime_downloader.sites import helpers
-
-logger = logging.getLogger(__name__)
 
 
 class AnimeFreak(Anime, sitename='animefreak'):

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -202,7 +202,6 @@ def parse_ep_str(anime, grammar):
             start, end = parse_episode_range(anime, episode_grammar).split(':')
             episode_grammar = '%d:%d' % (int(start), int(end) + 1)
             for episode in split_anime(anime, episode_grammar):
-                print(episode)
                 episodes.append(episode)
         else:
             from anime_downloader.sites.anime import AnimeEpisode

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -168,7 +168,7 @@ def split_anime(anime, episode_range):
     from anime_downloader.sites.anime import AnimeEpisode
     try:
         start, end = [int(x) for x in episode_range.split(':')]
-        ep_range = [str(x) for x in range(start, end)]
+        ep_range = [x for x in range(start, end)]
         eps = [x for x in anime._episode_urls if x[0] in ep_range]
 
         ep_cls = AnimeEpisode.subclasses[anime.sitename]
@@ -202,6 +202,7 @@ def parse_ep_str(anime, grammar):
             start, end = parse_episode_range(anime, episode_grammar).split(':')
             episode_grammar = '%d:%d' % (int(start), int(end) + 1)
             for episode in split_anime(anime, episode_grammar):
+                print(episode)
                 episodes.append(episode)
         else:
             from anime_downloader.sites.anime import AnimeEpisode

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -165,9 +165,14 @@ def download_metadata(file_format, metdata, episode, filename='metdata.json'):
 
 
 def split_anime(anime, episode_range):
+    from anime_downloader.sites.anime import AnimeEpisode
     try:
         start, end = [int(x) for x in episode_range.split(':')]
-        anime = anime[start - 1:end - 1]
+        ep_range = [str(x) for x in range(start, end)]
+        eps = [x for x in anime._episode_urls if x[0] in ep_range]
+
+        ep_cls = AnimeEpisode.subclasses[anime.sitename]
+        anime = [ep_cls(x[1], parent=anime, ep_no=x[0]) for x in eps]
     except ValueError:
         # Only one episode specified
         episode = int(episode_range)
@@ -180,7 +185,7 @@ def parse_episode_range(max_range, episode_range):
     if not episode_range:
         episode_range = '1:'
     if episode_range.endswith(':'):
-        length = max_range if type(max_range) == int else len(max_range)
+        length = max_range if type(max_range) == int else (int(max_range._episode_urls[-1][0]) - 1)
         episode_range += str(length + 1)
     if episode_range.startswith(':'):
         episode_range = '1' + episode_range
@@ -199,7 +204,12 @@ def parse_ep_str(anime, grammar):
             for episode in split_anime(anime, episode_grammar):
                 episodes.append(episode)
         else:
-            episodes.append(anime[int(episode_grammar) - 1])
+            from anime_downloader.sites.anime import AnimeEpisode
+
+            ep = [x for x in anime._episode_urls if x[0] == grammar][0]
+            ep_cls = AnimeEpisode.subclasses[anime.sitename]
+
+            episodes.append(ep_cls(ep[1], parent=anime, ep_no=ep[0]))
     return episodes
 
 

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -205,8 +205,7 @@ def parse_ep_str(anime, grammar):
                 episodes.append(episode)
         else:
             from anime_downloader.sites.anime import AnimeEpisode
-
-            ep = [x for x in anime._episode_urls if x[0] == grammar][0]
+            ep = [x for x in anime._episode_urls if x[0] == int(grammar)][0]
             ep_cls = AnimeEpisode.subclasses[anime.sitename]
 
             episodes.append(ep_cls(ep[1], parent=anime, ep_no=ep[0]))


### PR DESCRIPTION
Sometimes the episode count doesn't match the number of episodes (maybe due to missing episodes?). An example of this is One Piece, where the latest episode, 946, downloads as `Episode 942` instead of `Episode 946`