### PR TITLE
Add ability to queue anime 

### DIFF
--- a/anime_downloader/commands/dl.py
+++ b/anime_downloader/commands/dl.py
@@ -84,7 +84,7 @@ sitenames = [v[1] for v in ALL_ANIME_SITES]
 @click.option(
     "--queue", "-q",
     type=bool, is_flag=True,
-    help="Queue a series of anime"
+    help="Queue a list of anime"
 )
 @click.pass_context
 def command(ctx, anime_url, episode_range, url, player, skip_download, quality,

--- a/anime_downloader/commands/dl.py
+++ b/anime_downloader/commands/dl.py
@@ -93,30 +93,35 @@ def command(ctx, anime_url, episode_range, url, player, skip_download, quality,
     """ Download the anime using the url or search for it.
     """
     # Broken down by comma, and re-joined with comma, to remove trailing commas for accuracy with following len checks against choice and episode_range
-    anime_url = ",".join([x.strip() for x in anime_url.split(",") if x.strip() != ''])
+    anime_url = ",".join([x.strip()
+                          for x in anime_url.split(",") if x.strip() != ''])
     if choice:
         # Ensure that choice is only a combination of commas and numbers
         match = re.match("[\d,]+", choice)
         if not match or match.group() != choice:
-            raise UsageError(f"Invalid value for '--choice' / '-c': {choice} is not a valid integer/list of comma-delimited list of integers")
+            raise UsageError(
+                f"Invalid value for '--choice' / '-c': {choice} is not a valid integer/list of comma-delimited list of integers")
 
         choice = [x.strip() for x in choice.split(",") if x.strip()]
         # Check that length matches of choice list is equivalent to the number of specified anime
         if len(choice) != len(anime_url.split(",")):
-            raise UsageError(f"Invalid value for '--choice' / '-c': {','.join(choice)} does not have an equivalent number of arguments to {anime_url}")
-
+            raise UsageError(
+                f"Invalid value for '--choice' / '-c': {','.join(choice)} does not have an equivalent number of arguments to {anime_url}")
 
     if episode_range:
         # Check that only numeric characters, ',', and ':' are used
         match = re.match("[\d:,]+", episode_range)
 
         if not match or match.group() != episode_range:
-            raise UsageError("Invalid value for '--episodes' / '-e': only numerical characters, ',', and ':' are allowed")
+            raise UsageError(
+                "Invalid value for '--episodes' / '-e': only numerical characters, ',', and ':' are allowed")
 
-        episode_range = [x.strip() for x in episode_range.split(",") if x.strip()]
+        episode_range = [x.strip()
+                         for x in episode_range.split(",") if x.strip()]
 
         if len(episode_range) != len(anime_url.split(",")):
-            raise UsageError(f"Invalid value for '--episodes' / '-e: {','.join(episode_range)} does not have an equivalent number of arguments to {anime_url}")
+            raise UsageError(
+                f"Invalid value for '--episodes' / '-e: {','.join(episode_range)} does not have an equivalent number of arguments to {anime_url}")
 
     # anime_url changes after the first anime in the queue to the link of the previous anime
     original_url = anime_url
@@ -137,7 +142,8 @@ def command(ctx, anime_url, episode_range, url, player, skip_download, quality,
             if choice:
                 current_choice = int(choice[i])
 
-            anime_url, _ = util.search(original_url.split(",")[i], provider, current_choice)
+            anime_url, _ = util.search(original_url.split(",")[
+                                       i], provider, current_choice)
             cls = get_anime_class(anime_url)
 
         anime = cls(anime_url, quality=quality,

--- a/anime_downloader/commands/dl.py
+++ b/anime_downloader/commands/dl.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 import click
 import requests_cache
@@ -7,6 +8,7 @@ import requests_cache
 from anime_downloader import session, util
 from anime_downloader.__version__ import __version__
 from anime_downloader.sites import get_anime_class, ALL_ANIME_SITES, exceptions
+from click.exceptions import UsageError
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +21,7 @@ sitenames = [v[1] for v in ALL_ANIME_SITES]
 @click.argument('anime_url')
 @click.option(
     '--episodes', '-e', 'episode_range', metavar='<int>:<int>',
-    help="Range of anime you want to download in the form <start>:<end>")
+    help="Range of anime you want to download in the form <start>:<end>. If used with the -q/--queue flag, this must be a comma delimited list, e.g: <start>:<end>,<start>:<end> - the length must match the length of the number of anime provided")
 @click.option(
     '--url', '-u', type=bool, is_flag=True,
     help="If flag is set, prints the stream url instead of downloading")
@@ -69,8 +71,8 @@ sitenames = [v[1] for v in ALL_ANIME_SITES]
     help='Disable verifying the SSL certificate, if flag is set'
 )
 @click.option(
-    '--choice', '-c', type=int,
-    help='Choice to start downloading given anime number '
+    '--choice', '-c', type=str,
+    help='Choice to start downloading given anime number. If used with the -q/--queue flag, this must be a comma delimited list, e.g: -c number,number - the length must match the length of the number of anime provided'
 )
 @click.option("--skip-fillers", is_flag=True, help="Skip downloading of fillers.")
 @click.option(
@@ -79,73 +81,119 @@ sitenames = [v[1] for v in ALL_ANIME_SITES]
     help="Set the speed limit (in KB/s or MB/s) for downloading when using aria2c",
     metavar='<int>K/M'
 )
+@click.option(
+    "--queue", "-q",
+    type=bool, is_flag=True,
+    help="Queue a series of anime"
+)
 @click.pass_context
 def command(ctx, anime_url, episode_range, url, player, skip_download, quality,
             force_download, download_dir, file_format, provider,
-            external_downloader, chunk_size, disable_ssl, fallback_qualities, choice, skip_fillers, speed_limit):
+            external_downloader, chunk_size, disable_ssl, fallback_qualities, choice, skip_fillers, speed_limit, queue):
     """ Download the anime using the url or search for it.
     """
-    query = anime_url[:]
+    # Broken down by comma, and re-joined with comma, to remove trailing commas for accuracy with following len checks against choice and episode_range
+    anime_url = ",".join([x.strip() for x in anime_url.split(",") if x.strip() != ''])
+    if choice:
+        # Ensure that choice is only a combination of commas and numbers
+        match = re.match("[\d,]+", choice)
+        if not match or match.group() != choice:
+            raise UsageError(f"Invalid value for '--choice' / '-c': {choice} is not a valid integer/list of comma-delimited list of integers")
 
-    util.print_info(__version__)
-    # TODO: Replace by factory
-    cls = get_anime_class(anime_url)
+        choice = [x.strip() for x in choice.split(",") if x.strip()]
+        # Check that length matches of choice list is equivalent to the number of specified anime
+        if len(choice) != len(anime_url.split(",")):
+            raise UsageError(f"Invalid value for '--choice' / '-c': {','.join(choice)} does not have an equivalent number of arguments to {anime_url}")
 
-    disable_ssl = cls and cls.__name__ == 'Masterani' or disable_ssl
-    session.get_session().verify = not disable_ssl
 
-    if not cls:
-        anime_url, _ = util.search(anime_url, provider, choice)
-        cls = get_anime_class(anime_url)
+    if episode_range:
+        # Check that only numeric characters, ',', and ':' are used
+        match = re.match("[\d:,]+", episode_range)
 
-    anime = cls(anime_url, quality=quality,
-                fallback_qualities=fallback_qualities)
-    logger.info('Found anime: {}'.format(anime.title))
+        if not match or match.group() != episode_range:
+            raise UsageError("Invalid value for '--episodes' / '-e': only numerical characters, ',', and ':' are allowed")
 
-    animes = util.parse_ep_str(anime, episode_range)
-    if not animes:
-        # Issue #508.
-        raise exceptions.NotFoundError('No episodes found within index.')
+        episode_range = [x.strip() for x in episode_range.split(",") if x.strip()]
 
-    # TODO:
-    # Two types of plugins:
-    #   - Aime plugin: Pass the whole anime
-    #   - Ep plugin: Pass each episode
-    if url or player:
-        skip_download = True
+        if len(episode_range) != len(anime_url.split(",")):
+            raise UsageError(f"Invalid value for '--episodes' / '-e: {','.join(episode_range)} does not have an equivalent number of arguments to {anime_url}")
 
-    if download_dir and not skip_download:
-        logger.info('Downloading to {}'.format(os.path.abspath(download_dir)))
-    if skip_fillers:
-        fillers = util.get_filler_episodes(query)
-    if speed_limit:
-        logger.info("Speed is being limited to {}".format(speed_limit))
-    for episode in animes:
-        if skip_fillers and fillers:
-            if episode.ep_no in fillers:
-                logger.info("Skipping episode {} because it is a filler.".format(episode.ep_no))
-                continue
+    # anime_url changes after the first anime in the queue to the link of the previous anime
+    original_url = anime_url
+    for i in range(len(original_url.split(","))):
+        query = original_url.split(",")[i][:]
+        logger.info(original_url.split(","))
 
-        if url:
-            util.print_episodeurl(episode)
+        util.print_info(__version__)
+        # TODO: Replace by factory
+        cls = get_anime_class(original_url.split(",")[i])
 
-        if player:
-            util.play_episode(episode, player=player, title=f'{anime.title} - Episode {episode.ep_no}')
+        disable_ssl = cls and cls.__name__ == 'Masterani' or disable_ssl
+        session.get_session().verify = not disable_ssl
 
-        if not skip_download:
-            if external_downloader:
-                logging.info('Downloading episode {} of {}'.format(
-                    episode.ep_no, anime.title)
-                )
-                util.external_download(external_downloader, episode,
-                                       file_format, speed_limit, path=download_dir)
-                continue
-            if chunk_size is not None:
-                chunk_size *= 1e6
-                chunk_size = int(chunk_size)
-            with requests_cache.disabled():
-                episode.download(force=force_download,
-                                 path=download_dir,
-                                 format=file_format,
-                                 range_size=chunk_size)
-            print()
+        if not cls:
+            # Current choice is used, so if the user doesn't use the -c flag, there isn't a "NoneType isn't subscriptable error" when trying to index choice
+            current_choice = None
+            if choice:
+                current_choice = int(choice[i])
+
+            anime_url, _ = util.search(original_url.split(",")[i], provider, current_choice)
+            cls = get_anime_class(anime_url)
+
+        anime = cls(anime_url, quality=quality,
+                    fallback_qualities=fallback_qualities)
+        logger.info('Found anime: {}'.format(anime.title))
+
+        current_range = None
+        if episode_range:
+            current_range = episode_range[i]
+        animes = util.parse_ep_str(anime, current_range)
+        if not animes:
+            # Issue #508.
+            raise exceptions.NotFoundError('No episodes found within index.')
+
+        # TODO:
+        # Two types of plugins:
+        #   - Aime plugin: Pass the whole anime
+        #   - Ep plugin: Pass each episode
+        if url or player:
+            skip_download = True
+
+        if download_dir and not skip_download:
+            logger.info('Downloading to {}'.format(
+                os.path.abspath(download_dir)))
+        if skip_fillers:
+            fillers = util.get_filler_episodes(query)
+        if speed_limit:
+            logger.info("Speed is being limited to {}".format(speed_limit))
+        for episode in animes:
+            if skip_fillers and fillers:
+                if episode.ep_no in fillers:
+                    logger.info(
+                        "Skipping episode {} because it is a filler.".format(episode.ep_no))
+                    continue
+
+            if url:
+                util.print_episodeurl(episode)
+
+            if player:
+                util.play_episode(episode, player=player,
+                                  title=f'{anime.title} - Episode {episode.ep_no}')
+
+            if not skip_download:
+                if external_downloader:
+                    logging.info('Downloading episode {} of {}'.format(
+                        episode.ep_no, anime.title)
+                    )
+                    util.external_download(external_downloader, episode,
+                                           file_format, speed_limit, path=download_dir)
+                    continue
+                if chunk_size is not None:
+                    chunk_size *= 1e6
+                    chunk_size = int(chunk_size)
+                with requests_cache.disabled():
+                    episode.download(force=force_download,
+                                     path=download_dir,
+                                     format=file_format,
+                                     range_size=chunk_size)
+                print()


### PR DESCRIPTION
Closes #418.

The issue made 3 requests: 
• Auto-shutdown - this will not be added as per #419.
• An option to pause - this can be done by cancelling mid-download with aria2c, and re-running the command when you wish to continue.
• The ability to queue anime - this is what this PR is for.

Normal usage is unaffected. This PR adds a `-q` flag, which when used, allows the user to provide a comma delimited list of anime to queue: e.g: `anime dl -q "Naruto, Black Fox"`. When using the `-q`, if either the `-c` flag or the `-e` flag are used, they are also expected to be a comma delimited list of choices/episode selections and must match the number of queued anime.

I've tested and everything appears to work, but I recommend that others do rigorous testing as well. 