### PR TITLE
Change split anime test

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,12 +1,12 @@
 import pytest
 
 from anime_downloader import util
-
+from unittest.mock import Mock
 
 def test_split_anime():
-    anime_list = list(range(20))
-
-    assert len(util.split_anime(anime_list, '1:10')) == 9
+    anime = Mock()
+    anime._episode_urls = list(enumerate(range(20)))
+    assert len(util.split_anime(anime, '1:10')._episode_urls) == 9
 
 def test_check_in_path_exists():
     assert util.check_in_path('ls')


### PR DESCRIPTION
Due to changes to the split_anime method - split_anime now uses specific attributes of the anime object to do the splitting (so episode selection can be more accurate), this means that passing a list object will lead to an AttributeError, therefore we should replace it with a mock object 