### PR TITLE
Mpv launch arguments added.

### DIFF
--- a/anime_downloader/config.py
+++ b/anime_downloader/config.py
@@ -38,7 +38,8 @@ DEFAULT_CONFIG = {
         'fallback_qualities': ['720p', '480p', '360p'],
         'log_level': 'INFO',
         'provider': 'twist.moe',
-        'autoplay_next': True
+        'autoplay_next': True,
+        'mpv_arguments': ''
     },
     'gui': {
         'player': 'mpv'

--- a/anime_downloader/players/mpv.py
+++ b/anime_downloader/players/mpv.py
@@ -1,5 +1,6 @@
 from anime_downloader.players.baseplayer import BasePlayer
 from anime_downloader import config
+from anime_downloader.config import Config
 
 import os
 
@@ -20,13 +21,14 @@ class mpv(BasePlayer):
     @property
     def args(self):
         # Doesnt use the referer if it's none
+        launchArgs = Config['watch']['mpv_arguments']
         if self.episode.source().referer:
             return ['--input-conf=' + get_mpv_configfile(),
                     '--http-header-fields=referer: ' + str(self.episode.source().referer),
-                    self.episode.source().stream_url]
+                    self.episode.source().stream_url, launchArgs]
         else:
             return ['--input-conf=' + get_mpv_configfile(),
-                    self.episode.source().stream_url]
+                    self.episode.source().stream_url, launchArgs]
 
 
 def get_mpv_home():


### PR DESCRIPTION
Adds mpv launch arguments for issue: #589 . Run anime config, go to watch config options and mpv_arguments should now be an option. You can set this to --profile=Anime4k for example and mpv will launch with those arguments and any arguments you add ontop of it.