### PR TITLE
Animefreak: return list if there are multiple episodes for a given ep

### DIFF
--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -35,7 +35,7 @@ class AnimeFreak(Anime, sitename='animefreak'):
         episode_numbers = [int(re.search("episode-(\d+)", x.split("/")[-1]).group(1)) for x in episodes if re.search("episode-\d+", x.split("/")[-1])]
 
         # Ensure that the number of episode numbers which have been extracted match the number of episodes
-        if len(episodes) == len(episode_numbers):
+        if len(episodes) == len(episode_numbers) and len(episode_numbers) == len(set(episode_numbers)):
             return [(x, y) for x, y in zip(episode_numbers, episodes)]
 
         return episodes


### PR DESCRIPTION
The issue is noticed when anime has either specials (which may have numbers that the regex catches, thus leading to two Episode 1s), or when their are seasons (for example, Avatar - which has 3 'books' leading to duplicate episodes, and makes episode selection behave weird) 