### PR TITLE
Fix twist

### DIFF
--- a/anime_downloader/sites/twistmoe.py
+++ b/anime_downloader/sites/twistmoe.py
@@ -71,7 +71,7 @@ class TwistMoe(Anime, sitename='twist.moe'):
         episodes = episodes.json()
         logging.debug(episodes)
         self.title = anime_name
-        episode_urls = ['https://twistcdn.bunny.sh' +
+        episode_urls = ['https://cdn.twist.moe' +
                         decrypt(episode['source'].encode('utf-8')).decode('utf-8')
                         for episode in episodes]
 


### PR DESCRIPTION
This cdn can only get the backlog, not the airing cdn. They store airing on a different cdn it seems, It's kinda awkward to dynamically choose which cdn to switch, so I've just set the biggest library cdn

maybe we can make it as a config option or something?
