### PR TITLE
Subsplease: more helpful error when there are no search results

### DIFF
--- a/anime_downloader/sites/subsplease.py
+++ b/anime_downloader/sites/subsplease.py
@@ -1,6 +1,9 @@
 
+import logging
 from anime_downloader.sites.anime import Anime, AnimeEpisode, SearchResult
 from anime_downloader.sites import helpers
+
+logger = logging.getLogger(__name__)
 
 
 class SubsPlease(Anime, sitename="subsplease"):
@@ -13,6 +16,9 @@ class SubsPlease(Anime, sitename="subsplease"):
         # Tz for time zone - the parameter is required, but the value does not matter
         resp = helpers.get(cls.api_url, params={
                            "f": "search", "tz": "", "s": query}).json()
+
+        if type(resp) is list:
+            return
 
         # Using to deduplicate
         slug_to_title_dict = dict(


### PR DESCRIPTION
When there are no results on subsplease, an empty list is returned instead of a dictionary. By returning nothing in such cases, we get the more obvious error `anime: No such Anime found. Please ensure correct spelling.` as opposed to an `AttributeError`