### PR TITLE
Animefreak: Do not use cache when getting sources for anime episodes

### DIFF
--- a/anime_downloader/sites/animefreak.py
+++ b/anime_downloader/sites/animefreak.py
@@ -32,7 +32,8 @@ class AnimeFreak(Anime, sitename='animefreak'):
         episodes = [a.get('href') for a in episode_links][::-1]
 
         # Get links ending with episode-.*, e.g. episode-74
-        episode_numbers = [int(re.search("episode-(\d+)", x.split("/")[-1]).group(1)) for x in episodes if re.search("episode-\d+", x.split("/")[-1])]
+        episode_numbers = [int(re.search("episode-(\d+)", x.split("/")[-1]).group(1))
+                           for x in episodes if re.search("episode-\d+", x.split("/")[-1])]
 
         # Ensure that the number of episode numbers which have been extracted match the number of episodes
         if len(episodes) == len(episode_numbers) and len(episode_numbers) == len(set(episode_numbers)):
@@ -47,7 +48,7 @@ class AnimeFreak(Anime, sitename='animefreak'):
 
 class AnimeFreakEpisode(AnimeEpisode, sitename='animefreak'):
     def _get_sources(self):
-        page = helpers.get(self.url).text
+        page = helpers.get(self.url, cache=False).text
         source_re = re.compile(r'loadVideo.+file: "([^"]+)', re.DOTALL)
         match = source_re.findall(page)
 


### PR DESCRIPTION
<!--
If you are adding a provider, please remember to:

- Add the provider to README.md

If there are any related issues, please mention them - e.g:

Closes #372
Closes #284

All modified python files should have `autopep8 --in-place file.py` run on them to ensure that they follow PEP8 standards
-->

Animefreak links have tokens which cause them to expire after some time. In very rare instances this can cause issues. 