### PR TITLE
fixed the multiple ep selection using commas

### DIFF
--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -211,7 +211,7 @@ def parse_ep_str(anime, grammar):
                 ep = sorted(anime._episode_urls)[-1]
             else:
                 ep = [x for x in anime._episode_urls if x[0]
-                      == int(grammar)][0]
+                      == int(episode_grammar)][0]
 
             ep_cls = AnimeEpisode.subclasses[anime.sitename]
 

--- a/anime_downloader/util.py
+++ b/anime_downloader/util.py
@@ -207,7 +207,7 @@ def parse_ep_str(anime, grammar):
         else:
             from anime_downloader.sites.anime import AnimeEpisode
 
-            if grammar == '0':
+            if episode_grammar == '0':
                 ep = sorted(anime._episode_urls)[-1]
             else:
                 ep = [x for x in anime._episode_urls if x[0]


### PR DESCRIPTION
<!--
If you are adding a provider, please remember to:

- Add the provider to README.md

If there are any related issues, please mention them - e.g:

Closes #372
Closes #284

All modified python files should have `autopep8 --in-place file.py` run on them to ensure that they follow PEP8 standards
-->
this now fixes the error when trying to select eps with commas
