### PR TITLE
Kwik Fixes

### DIFF
--- a/anime_downloader/config.py
+++ b/anime_downloader/config.py
@@ -73,6 +73,9 @@ DEFAULT_CONFIG = {
         'anistream.xyz': {
             'version': 'subbed',
         },
+        'animepahe': {
+            'version': 'subbed',
+        },
         'animeflv': {
             'version': 'subbed',
             'servers': [

--- a/anime_downloader/extractors/kwik.py
+++ b/anime_downloader/extractors/kwik.py
@@ -29,17 +29,15 @@ class Kwik(BaseExtractor):
         # have to rebuild the url. Hopefully kwik doesn't block this too
 
         # Necessary
-        #ld(self.url)
+        # ld(self.url)
         #self.url = self.url.replace(".cx/e/", ".cx/f/")
         #self.headers.update({"referer": self.url})
 
         headers = {"Referer": "https://kwik.cx/"}
 
-        
-        
         res = requests.get(self.url, headers=headers)
 
-        #ld(res.text)
+        # ld(res.text)
 
         evalText = helpers.soupify(res.text)
 
@@ -57,18 +55,19 @@ class Kwik(BaseExtractor):
 
         with open(tf, 'w', encoding="utf-8") as f:
             f.write(rexd)
-        
-        #print(tf)
 
-        #ld(nodeRes)
-        
+        # print(tf)
+
+        # ld(nodeRes)
+
         nodeRes = str(subprocess.getoutput(f"node {tf}"))
 
         ld(nodeRes)
 
-        stream_url = re.search(r"source='([^;]*)';", nodeRes).group().replace("source='", "").replace("';", "")
+        stream_url = re.search(
+            r"source='([^;]*)';", nodeRes).group().replace("source='", "").replace("';", "")
         #reg = re.compile("[\s\S]*")
-        
+
         ld(stream_url)
 
         #kwik_text = resp.text
@@ -78,30 +77,25 @@ class Kwik(BaseExtractor):
 
         return {
             'stream_url': stream_url,
-#            'meta': {
-#                'title': title,
-#                'thumbnail': ''
-#            },
+            # 'meta': {
+            #   'title': title,
+            #   'thumbnail': ''
+            # },
             'referer': "https://kwik.cx/"
         }
 
-        
-        
-
         #cookies = util.get_hcaptcha_cookies(self.url)
 
-        #if not cookies:
+        # if not cookies:
         #    resp = util.bypass_hcaptcha(self.url)
-        #else:
+        # else:
         #    resp = requests.get(self.url, cookies=cookies)
-
-        
 
         #
         #deobfuscated = None
 
         #loops = 0
-        #while not deobfuscated and loops < 6:
+        # while not deobfuscated and loops < 6:
         #    try:
         #        deobfuscated = helpers.soupify(util.deobfuscate_packed_js(re.search(r'<(script).*(var\s+_.*escape.*?)</\1>(?s)', kwik_text).group(2)))
         #    except (AttributeError, CalledProcessError) as e:
@@ -113,7 +107,7 @@ class Kwik(BaseExtractor):
         #            resp = requests.get(self.url, cookies=cookies)
         #    finally:
         #        cookies = resp.cookies
-        #        
+        #
         #        loops += 1
 
         #post_url = deobfuscated.form["action"]
@@ -124,11 +118,11 @@ class Kwik(BaseExtractor):
 
         #logger.debug('Stream URL: %s' % stream_url)
 
-        #return {
+        # return {
         #    'stream_url': stream_url,
         #    'meta': {
         #        'title': title,
         #        'thumbnail': ''
         #    },
         #    'referer': None
-        #}
+        # }

--- a/anime_downloader/extractors/kwik.py
+++ b/anime_downloader/extractors/kwik.py
@@ -1,10 +1,15 @@
 import logging
+from platform import node
 import re
+import subprocess
 import requests
+import tempfile
 
 from anime_downloader.extractors.base_extractor import BaseExtractor
+from anime_downloader.sites.helpers.request import temp_dir
 from anime_downloader.sites import helpers
 from anime_downloader import util
+from anime_downloader.util import eval_in_node
 from subprocess import CalledProcessError
 
 logger = logging.getLogger(__name__)
@@ -18,55 +23,112 @@ class Kwik(BaseExtractor):
     '''
 
     def _get_data(self):
+        ld = logger.debug
         # Kwik servers don't have direct link access you need to be referred
         # from somewhere, I will just use the url itself. We then
         # have to rebuild the url. Hopefully kwik doesn't block this too
 
         # Necessary
-        self.url = self.url.replace(".cx/e/", ".cx/f/")
-        self.headers.update({"referer": self.url})
+        #ld(self.url)
+        #self.url = self.url.replace(".cx/e/", ".cx/f/")
+        #self.headers.update({"referer": self.url})
 
-        cookies = util.get_hcaptcha_cookies(self.url)
+        headers = {"Referer": "https://kwik.cx/"}
 
-        if not cookies:
-            resp = util.bypass_hcaptcha(self.url)
-        else:
-            resp = requests.get(self.url, cookies=cookies)
+        
+        
+        res = requests.get(self.url, headers=headers)
 
-        title_re = re.compile(r'title>(.*)<')
+        #ld(res.text)
 
-        kwik_text = resp.text
-        deobfuscated = None
+        evalText = helpers.soupify(res.text)
 
-        loops = 0
-        while not deobfuscated and loops < 6:
-            try:
-                deobfuscated = helpers.soupify(util.deobfuscate_packed_js(re.search(r'<(script).*(var\s+_.*escape.*?)</\1>(?s)', kwik_text).group(2)))
-            except (AttributeError, CalledProcessError) as e:
-                if type(e) == AttributeError:
-                    resp = util.bypass_hcaptcha(self.url)
-                    kwik_text = resp.text
+        scripts = evalText.select("script")
 
-                if type(e) == CalledProcessError:
-                    resp = requests.get(self.url, cookies=cookies)
-            finally:
-                cookies = resp.cookies
-                title = title_re.search(kwik_text).group(1)
-                loops += 1
+        for i in scripts:
+            rexd = re.compile("<script>eval[\s\S]*<\/script>").match(str(i))
+            if not rexd == None:
+                rexd = rexd.group()
+                rexd = rexd.replace("<script>", "")
+                rexd = rexd.replace("</script>", "")
+                break
 
-        post_url = deobfuscated.form["action"]
-        token = deobfuscated.input["value"]
+        tf = tempfile.mktemp(dir=temp_dir)
 
-        resp = helpers.post(post_url, headers=self.headers, params={"_token": token}, cookies=cookies, allow_redirects=False)
-        stream_url = resp.headers["Location"]
+        with open(tf, 'w', encoding="utf-8") as f:
+            f.write(rexd)
+        
+        #print(tf)
 
-        logger.debug('Stream URL: %s' % stream_url)
+        #ld(nodeRes)
+        
+        nodeRes = str(subprocess.getoutput(f"node {tf}"))
+
+        ld(nodeRes)
+
+        stream_url = re.search(r"source='([^;]*)';", nodeRes).group().replace("source='", "").replace("';", "")
+        #reg = re.compile("[\s\S]*")
+        
+        ld(stream_url)
+
+        #kwik_text = resp.text
+
+        #title_re = re.compile(r'title>(.*)<')
+        #title = title_re.search(kwik_text).group(1)
 
         return {
             'stream_url': stream_url,
-            'meta': {
-                'title': title,
-                'thumbnail': ''
-            },
-            'referer': None
+#            'meta': {
+#                'title': title,
+#                'thumbnail': ''
+#            },
+            'referer': "https://kwik.cx/"
         }
+
+        
+        
+
+        #cookies = util.get_hcaptcha_cookies(self.url)
+
+        #if not cookies:
+        #    resp = util.bypass_hcaptcha(self.url)
+        #else:
+        #    resp = requests.get(self.url, cookies=cookies)
+
+        
+
+        #
+        #deobfuscated = None
+
+        #loops = 0
+        #while not deobfuscated and loops < 6:
+        #    try:
+        #        deobfuscated = helpers.soupify(util.deobfuscate_packed_js(re.search(r'<(script).*(var\s+_.*escape.*?)</\1>(?s)', kwik_text).group(2)))
+        #    except (AttributeError, CalledProcessError) as e:
+        #        if type(e) == AttributeError:
+        #            resp = util.bypass_hcaptcha(self.url)
+        #            kwik_text = resp.text
+
+        #        if type(e) == CalledProcessError:
+        #            resp = requests.get(self.url, cookies=cookies)
+        #    finally:
+        #        cookies = resp.cookies
+        #        
+        #        loops += 1
+
+        #post_url = deobfuscated.form["action"]
+        #token = deobfuscated.input["value"]
+
+        #resp = helpers.post(post_url, headers=self.headers, params={"_token": token}, cookies=cookies, allow_redirects=False)
+        #stream_url = resp.headers["Location"]
+
+        #logger.debug('Stream URL: %s' % stream_url)
+
+        #return {
+        #    'stream_url': stream_url,
+        #    'meta': {
+        #        'title': title,
+        #        'thumbnail': ''
+        #    },
+        #    'referer': None
+        #}

--- a/anime_downloader/extractors/kwik.py
+++ b/anime_downloader/extractors/kwik.py
@@ -1,65 +1,122 @@
-import logging
-from platform import node
-import re
-import subprocess
+from base64 import b64decode
 import requests
-import tempfile
+import logging
+import re
 
 from anime_downloader.extractors.base_extractor import BaseExtractor
-from anime_downloader.sites.helpers.request import temp_dir
 from anime_downloader.sites import helpers
-from anime_downloader import util
-from anime_downloader.util import eval_in_node
 from subprocess import CalledProcessError
+from anime_downloader import util
 
 logger = logging.getLogger(__name__)
 
 
 class Kwik(BaseExtractor):
-    '''Extracts video url from kwik pages, Kwik has some `security`
-       which allows to access kwik pages when only referred by something
-       and the kwik video stream when referred through the corresponding
-       kwik video page.
-    '''
+    YTSM = re.compile(r"ysmm = '([^']+)")
+
+    KWIK_PARAMS_RE = re.compile(r'\("(\w+)",\d+,"(\w+)",(\d+),(\d+),\d+\)')
+    KWIK_D_URL = re.compile(r'action="([^"]+)"')
+    KWIK_D_TOKEN = re.compile(r'value="([^"]+)"')
+
+    CHARACTER_MAP = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ+/"
+
+    def get_string(self, content: str, s1: int, s2: int) -> str:
+        slice_2 = self.CHARACTER_MAP[0:s2]
+
+        acc = 0
+        for n, i in enumerate(content[::-1]):
+            acc += int(i if i.isdigit() else 0) * s1**n
+
+        k = ''
+        while acc > 0:
+            k = slice_2[int(acc % s2)] + k
+            acc = (acc - (acc % s2)) / s2
+
+        return k or '0'
+
+    def decrypt(self, full_string: str, key: str, v1: int, v2: int) -> str:
+        v1, v2 = int(v1), int(v2)
+        r, i = "", 0
+
+        while i < len(full_string):
+            s = ""
+            while (full_string[i] != key[v2]):
+                s += full_string[i]
+                i += 1
+            j = 0
+            while j < len(key):
+                s = s.replace(key[j], str(j))
+                j += 1
+            r += chr(int(self.get_string(s, v2, 10)) - v1)
+            i += 1
+        return r
+
+    def decode_adfly(self, coded_key: str) -> str:
+        r, j = '', ''
+        for n, l in enumerate(coded_key):
+            if not n % 2:
+                r += l
+            else:
+                j = l + j
+
+        encoded_uri = list(r + j)
+        numbers = ((i, n) for i, n in enumerate(encoded_uri) if str.isdigit(n))
+        for first, second in zip(numbers, numbers):
+            xor = int(first[1]) ^ int(second[1])
+            if xor < 10:
+                encoded_uri[first[0]] = str(xor)
+
+        return b64decode(("".join(encoded_uri)).encode("utf-8")
+                         )[16:-16].decode('utf-8', errors='ignore')
+
+    def bypass_adfly(self, adfly_url):
+        session = requests.session()
+
+        response_code = 302
+        while response_code != 200:
+            adfly_content = session.get(
+                session.get(
+                    adfly_url,
+                    allow_redirects=False).headers.get('location'),
+                allow_redirects=False)
+            response_code = adfly_content.status_code
+        return self.decode_adfly(self.YTSM.search(adfly_content.text).group(1))
+
+    def get_stream_url_from_kwik(self, adfly_url):
+        session = requests.session()
+
+        f_content = requests.get(
+            self.bypass_adfly(adfly_url),
+            headers={
+                'referer': 'https://kwik.cx/'
+            }
+        )
+        decrypted = self.decrypt(
+            *
+            self.KWIK_PARAMS_RE.search(
+                f_content.text
+            ).group(
+                1, 2,
+                3, 4
+            )
+        )
+
+        code = 419
+        while code != 302:
+            content = session.post(
+                self.KWIK_D_URL.search(decrypted).group(1),
+                allow_redirects=False,
+                data={
+                    '_token': self.KWIK_D_TOKEN.search(decrypted).group(1)},
+                headers={
+                    'referer': str(f_content.url),
+                    'cookie': f_content.headers.get('set-cookie')})
+            code = content.status_code
+
+        return content.headers.get('location')
 
     def _get_data(self):
-        ld = logger.debug
-        # Kwik servers don't have direct link access you need to be referred
-        # from somewhere, I will just use the url itself. We then
-        # have to rebuild the url. Hopefully kwik doesn't block this too
-
-        # Necessary
-
-        headers = {"Referer": "https://kwik.cx/"}
-
-        res = requests.get(self.url, headers=headers)
-
-        evalText = helpers.soupify(res.text)
-
-        scripts = evalText.select("script")
-
-        for i in scripts:
-            rexd = re.compile("<script>eval[\s\S]*<\/script>").match(str(i))
-            if not rexd == None:
-                rexd = rexd.group()
-                rexd = rexd.replace("<script>", "")
-                rexd = rexd.replace("</script>", "")
-                break
-
-        tf = tempfile.mktemp(dir=temp_dir)
-
-        with open(tf, 'w', encoding="utf-8") as f:
-            f.write(rexd)
-        nodeRes = str(subprocess.getoutput(f"node {tf}"))
-
-        ld(nodeRes)
-
-        stream_url = re.search(
-            r"source='([^;]*)';", nodeRes).group().replace("source='", "").replace("';", "")
-
-        ld(stream_url)
-
         return {
-            'stream_url': stream_url,
-            'referer': "https://kwik.cx/"
+            'stream_url': self.get_stream_url_from_kwik(self.url),
+            'referer': None
         }

--- a/anime_downloader/extractors/kwik.py
+++ b/anime_downloader/extractors/kwik.py
@@ -29,15 +29,10 @@ class Kwik(BaseExtractor):
         # have to rebuild the url. Hopefully kwik doesn't block this too
 
         # Necessary
-        # ld(self.url)
-        #self.url = self.url.replace(".cx/e/", ".cx/f/")
-        #self.headers.update({"referer": self.url})
 
         headers = {"Referer": "https://kwik.cx/"}
 
         res = requests.get(self.url, headers=headers)
-
-        # ld(res.text)
 
         evalText = helpers.soupify(res.text)
 
@@ -55,74 +50,16 @@ class Kwik(BaseExtractor):
 
         with open(tf, 'w', encoding="utf-8") as f:
             f.write(rexd)
-
-        # print(tf)
-
-        # ld(nodeRes)
-
         nodeRes = str(subprocess.getoutput(f"node {tf}"))
 
         ld(nodeRes)
 
         stream_url = re.search(
             r"source='([^;]*)';", nodeRes).group().replace("source='", "").replace("';", "")
-        #reg = re.compile("[\s\S]*")
 
         ld(stream_url)
 
-        #kwik_text = resp.text
-
-        #title_re = re.compile(r'title>(.*)<')
-        #title = title_re.search(kwik_text).group(1)
-
         return {
             'stream_url': stream_url,
-            # 'meta': {
-            #   'title': title,
-            #   'thumbnail': ''
-            # },
             'referer': "https://kwik.cx/"
         }
-
-        #cookies = util.get_hcaptcha_cookies(self.url)
-
-        # if not cookies:
-        #    resp = util.bypass_hcaptcha(self.url)
-        # else:
-        #    resp = requests.get(self.url, cookies=cookies)
-
-        #
-        #deobfuscated = None
-
-        #loops = 0
-        # while not deobfuscated and loops < 6:
-        #    try:
-        #        deobfuscated = helpers.soupify(util.deobfuscate_packed_js(re.search(r'<(script).*(var\s+_.*escape.*?)</\1>(?s)', kwik_text).group(2)))
-        #    except (AttributeError, CalledProcessError) as e:
-        #        if type(e) == AttributeError:
-        #            resp = util.bypass_hcaptcha(self.url)
-        #            kwik_text = resp.text
-
-        #        if type(e) == CalledProcessError:
-        #            resp = requests.get(self.url, cookies=cookies)
-        #    finally:
-        #        cookies = resp.cookies
-        #
-        #        loops += 1
-
-        #post_url = deobfuscated.form["action"]
-        #token = deobfuscated.input["value"]
-
-        #resp = helpers.post(post_url, headers=self.headers, params={"_token": token}, cookies=cookies, allow_redirects=False)
-        #stream_url = resp.headers["Location"]
-
-        #logger.debug('Stream URL: %s' % stream_url)
-
-        # return {
-        #    'stream_url': stream_url,
-        #    'meta': {
-        #        'title': title,
-        #        'thumbnail': ''
-        #    },
-        #    'referer': None
-        # }

--- a/anime_downloader/sites/animepahe.py
+++ b/anime_downloader/sites/animepahe.py
@@ -91,18 +91,17 @@ class AnimePaheEpisode(AnimeEpisode, sitename='animepahe'):
             else:
                 raise NotFoundError
 
-        episode_data = helpers.get(self.url, cf=True).json()
+        episode_data = helpers.get(self.url).json()
 
-        episode_data = episode_data['data']
-        sources_list = []
+        data = episode_data['data']
+        qualities = [x + 'p' for f in data for x in f]
 
-        for info in range(len(episode_data)):
-            quality = list(episode_data[info].keys())[0]
-            sources_list.append({
-                'extractor': 'kwik',
-                'url': episode_data[info][quality]['kwik'],
-                'server': 'kwik',
-                'version': 'subbed'
-            })
+        sources_list = [
+           f[x]['kwik_adfly'] for f in data for x in f
+        ]
 
-        return self.sort_sources(sources_list)
+        for i, quality in enumerate(qualities):
+            if self.quality == quality:
+                return [("kwik", sources_list[i])]
+
+        return [("kwik", x) for x in sources_list]

--- a/anime_downloader/sites/animepahe.py
+++ b/anime_downloader/sites/animepahe.py
@@ -74,7 +74,7 @@ class AnimePahe(Anime, sitename='animepahe'):
         for search_result in search_results['data']:
             search_result_info = SearchResult(
                 title=search_result['title'],
-                url=cls.base_anime_url + search_result['slug'],
+                url=cls.base_anime_url + search_result['session'],
                 poster=search_result['poster']
             )
 

--- a/anime_downloader/sites/animepahe.py
+++ b/anime_downloader/sites/animepahe.py
@@ -21,7 +21,8 @@ class AnimePaheEpisode(AnimeEpisode, sitename='animepahe'):
             'session': session_id
         }
 
-        episode_data = helpers.get('https://animepahe.com/api', params=params).json()
+        episode_data = helpers.get(
+            'https://animepahe.com/api', params=params).json()
         episode_data = episode_data['data']
         sources = {}
 
@@ -39,7 +40,8 @@ class AnimePaheEpisode(AnimeEpisode, sitename='animepahe'):
         sources = []
 
         server_list = re.findall(r'data-provider="([^"]+)', source_text)
-        episode_id, session_id = re.search("getUrls\((\d+?), \"(.*)?\"", source_text).groups()
+        episode_id, session_id = re.search(
+            "getUrls\((\d+?), \"(.*)?\"", source_text).groups()
 
         for server in server_list:
             if server not in supported_servers:

--- a/anime_downloader/sites/init.py
+++ b/anime_downloader/sites/init.py
@@ -18,6 +18,7 @@ ALL_ANIME_SITES = [
     ('animetake','animetake','AnimeTake'),
     ('animeonline','animeonline360','AnimeOnline'),
     ('animeout', 'animeout', 'AnimeOut'),
+    ('animepahe', 'animepahe', 'AnimePahe'),
     ('animerush', 'animerush', 'AnimeRush'),
     ('animesimple', 'animesimple', 'AnimeSimple'),
     ('animesuge', 'animesuge', 'AnimeSuge'),


### PR DESCRIPTION
fixes later parts of #412
animepahe returns a m3u8 so it isn't too helpful when downloading but ffmpeg can convert it to an mp4 with:

```
ffmpeg -headers "Referer: https://kwik.cx/" -i {link goes here} -c copy anime.mp4
```

