### PR TITLE
the extractors getter now uses actual regex instead of substring search

### DIFF
--- a/anime_downloader/extractors/init.py
+++ b/anime_downloader/extractors/init.py
@@ -1,4 +1,6 @@
 from importlib import import_module
+import re
+
 
 ALL_EXTRACTORS = [
     {
@@ -186,7 +188,7 @@ ALL_EXTRACTORS = [
 
 def get_extractor(name):
     for extractor in ALL_EXTRACTORS:
-        if extractor['regex'] in name.lower():
+        if re.match(extractor['regex'], name.lower()):
             module = import_module(
                 'anime_downloader.extractors.{}'.format(
                     extractor['modulename'])


### PR DESCRIPTION
<!--
If you are adding a provider, please remember to:

- Add the provider to README.md

If there are any related issues, please mention them - e.g:

Closes #372
Closes #284

All modified python files should have `autopep8 --in-place file.py` run on them to ensure that they follow PEP8 standards
-->
I basically make the extractors getter actually use regex to find the extractor, smth it did not do before.
