### PR TITLE
Fix bug in anime watch with empty watch list not exiting automatically and update provider lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,44 +55,25 @@ Yeah. Me too! That's why this tool exists.
 **Details about the sites can be found in [FAQ](https://github.com/anime-dl/anime-downloader/wiki/FAQ)**
 
 
-- AnimePahe
 - AnimTime
 - AnimeBinge
-- Animedaisuki
-- Animeflix
 - Animeflv
-- Animefreak
-- AnimeKisa
 - AnimeOnline360
-- animeout
 - Animerush
-- Animesimple
 - AnimeStar
-- AnimeSuge - requires Node.js
 - Animevibe
-- AnimeTake
-- AniTube
-- Animixplay
-- Anistream
-- Darkanime
 - Dbanimes 
 - EraiRaws
 - EgyAnime - usually m3u8 (good for streaming, not so much for downloading)
 - GenoAnime
-- GurminderBoparai (AnimeChameleon)
 - itsaturday
-- Justdubs
-- Kissanimefree
+- Justdubs?
 - KissanimeX
 - Nyaa.si
-- PutLockers
-- RyuAnime
-- Shiro.is
 - SubsPlease
 - twist.moe - requires Node.js
 - tenshi.moe
 - Vidstream
-- Voiranime
 - Vostfree
 - Wcostream
 

--- a/anime_downloader/commands/watch.py
+++ b/anime_downloader/commands/watch.py
@@ -66,6 +66,13 @@ def command(anime_name, new, update_all, _list, quality, remove,
     util.print_info(__version__)
     watcher = _watch.Watcher()
 
+    with open(watcher.WATCH_FILE, "r") as f:
+            contents = f.read()
+            # print(contents)
+            if "[]" in contents or "[{}]" in contents:
+                logger.error("Add something to the watch list using `anime watch --new`")
+                sys.exit(1)
+
     if new:
         if anime_name:
             query = anime_name

--- a/anime_downloader/sites/init.py
+++ b/anime_downloader/sites/init.py
@@ -5,41 +5,41 @@ ALL_ANIME_SITES = [
     # ('_4anime', '4anime', 'Anime4'),
     ('anitube', 'anitube', 'AniTube'),
     ('animtime', 'animtime', 'AnimTime'),
-    ('anime8', 'anime8', 'Anime8'),
+    # ('anime8', 'anime8', 'Anime8'),
     ('animebinge', 'animebinge', 'AnimeBinge'),
-    ('animechameleon', 'gurminder', 'AnimeChameleon'),
-    ('animedaisuki', 'animedaisuki', 'Animedaisuki'),
-    ('animeflix', 'animeflix', 'AnimeFlix'),
-    ('animeflv', 'animeflv', 'Animeflv'),
-    ('animefreak', 'animefreak', 'AnimeFreak'),
+    # ('animechameleon', 'gurminder', 'AnimeChameleon'), # Gone
+    # ('animedaisuki', 'animedaisuki', 'Animedaisuki'), # Under maintenance?
+    # ('animeflix', 'animeflix', 'AnimeFlix'),
+    ('animeflv', 'animeflv', 'Animeflv'), # Shows as timed out, but loads in the browser
+    # ('animefreak', 'animefreak', 'AnimeFreak'), # Gone, Problem loading page
     ('animefree','animefree','AnimeFree'),
     # ('animefrenzy','animefrenzy','AnimeFrenzy'),
     ('animekisa','animekisa','AnimeKisa'),
-    ('animetake','animetake','AnimeTake'),
+    # ('animetake','animetake','AnimeTake'), # Cloudflare
     ('animeonline','animeonline360','AnimeOnline'),
-    ('animeout', 'animeout', 'AnimeOut'),
+    # ('animeout', 'animeout', 'AnimeOut'), # Cloudflare
     # ('animepahe', 'animepahe', 'AnimePahe'),
-    ('animerush', 'animerush', 'AnimeRush'),
-    ('animesimple', 'animesimple', 'AnimeSimple'),
+    ('animerush', 'animerush', 'AnimeRush'), 
+    # ('animesimple', 'animesimple', 'AnimeSimple'), # Needs some work, might still work
     ('animestar', 'animestar', 'AnimeStar'),
-    ('animesuge', 'animesuge', 'AnimeSuge'),
+    # ('animesuge', 'animesuge', 'AnimeSuge'), # Gone, Problem loading page
     ('animevibe', 'animevibe', 'AnimeVibe'),
-    ('animixplay', 'animixplay', 'AniMixPlay'),
-    ('darkanime', 'darkanime', 'DarkAnime'),
+    # ('animixplay', 'animixplay', 'AniMixPlay'), # Needs much work to fix I assume, links are prob not the same
+    # ('darkanime', 'darkanime', 'DarkAnime'), # It No Load
     ('dbanimes', 'dbanimes', 'DBAnimes'),
-    ('erairaws', 'erai-raws', 'EraiRaws'),
-    ('egyanime', 'egyanime', 'EgyAnime'),
+    ('erairaws', 'erai-raws', 'EraiRaws'), # Currently under maitenance
+    ('egyanime', 'egyanime', 'EgyAnime'), 
     ('genoanime', 'genoanime', 'GenoAnime'),
     ('itsaturday', 'itsaturday', 'Itsaturday'),
-    ('justdubs', 'justdubs', 'JustDubs'),
+    ('justdubs', 'justdubs', 'JustDubs'), # Blocked on my VPN
     # ('kickass', 'kickass', 'KickAss'),
     ('kissanimex', 'kissanimex', 'KissAnimeX'),
     # ('kisscartoon', 'kisscartoon', 'KissCartoon'),
     # ('nineanime', '9anime', 'NineAnime'),
     ('nyaa', 'nyaa', 'Nyaa'),
-    ('putlockers', 'putlockers', 'PutLockers'),
-    ('ryuanime', 'ryuanime', 'RyuAnime'),
-    ('shiro', 'shiro', 'Shiro'),
+    # ('putlockers', 'putlockers', 'PutLockers'), # Cloudflare
+    ('ryuanime', 'ryuanime', 'RyuAnime'), # Needs updating links and prob just a rework of scraper
+    # ('shiro', 'shiro', 'Shiro'), # Requires Login
     ('subsplease', 'subsplease', 'SubsPlease'),
     ('twistmoe', 'twist.moe', 'TwistMoe'),
     ('tenshimoe', 'tenshi.moe', 'TenshiMoe'),


### PR DESCRIPTION
<!--
If you are adding a provider, please remember to:

- Add the provider to README.md

If there are any related issues, please mention them - e.g:

Closes #372
Closes #284

All modified python files should have `autopep8 --in-place file.py` run on them to ensure that they follow PEP8 standards
-->
Closes #724